### PR TITLE
add Lithium release

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -597,6 +597,10 @@
     {
       "release_name": "Helium",
       "end_date": "2014-Sep-29"
+    },
+    {
+      "release_name": "Lithium",
+      "end_date": "2015-Jun-25"
     }
   ],
   "mail_lists": [


### PR DESCRIPTION
The processor won't process anything after the last release that is
defined. As we are now in the Lithium release cycle and the planned
release date is 2015-06-25 set that as the newest release.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>