### PR TITLE
Revert "Add custom configuration for the LISPflowmapping repo"

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -630,33 +630,7 @@
       ]
     }
   ],
-  "repos": [
-    {
-      "releases": [
-        {
-          "branch": "stable/hydrogen",
-          "tag_to": "HEAD",
-          "release_name": "Hydrogen",
-          "tag_from": "f5087c8"
-        },
-        {
-          "branch": "stable/helium",
-          "tag_to": "HEAD",
-          "release_name": "Helium",
-          "tag_from": "42c04ed"
-        },
-        {
-          "branch": "develop",
-          "tag_to": "HEAD",
-          "release_name": "Current",
-          "tag_from": "8e1dc0f"
-        }
-      ],
-     "uri": "https://git.opendaylight.org/gerrit/p/lispflowmapping.git",
-     "module": "lispflowmapping",
-     "organization": "opendaylight"
-    }
-  ],
+  "repos": [],
   "project_sources": [
     {
       "organization": "opendaylight",


### PR DESCRIPTION
LISPflowmapping dropped the use of the "develop" branch for current
development and moved to master like everyone else.  In addition, the
change that this patch reverts is making statistics based on branch
names instead of dates like the default configuration, so the results
are not directly comparable.

This reverts commit 8ebdfd2d5d009c25d765271cc049dbeae2e7cdcd.